### PR TITLE
Fix ruff command in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install ruff mypy
       - name: Ruff
-        run: ruff .
+        run: ruff check .
       - name: Mypy
         run: mypy --strict .
 


### PR DESCRIPTION
## Summary
- run `ruff check .` instead of deprecated `ruff .`

## Testing
- `ruff check .`
- `mypy --strict .`
- `pytest -n auto --cov --cov-fail-under=90` *(fails: coverage < 90%)*

------
https://chatgpt.com/codex/tasks/task_e_6876ccf38b9c832c80361bf527db2527