### PR TITLE
docs: capture backlog grooming notes

### DIFF
--- a/docs/6_Dev Env & Collaboration/4_Communication & Meeting Cadence Plan/communication-plan.md
+++ b/docs/6_Dev Env & Collaboration/4_Communication & Meeting Cadence Plan/communication-plan.md
@@ -22,6 +22,8 @@ This plan defines how collaboration occurs on the Protocol to CRF Generator proj
 
 These meetings may be cancelled if there are no agenda items. Action items are captured in GitHub Issues for traceability.
 
+Backlog grooming sessions review the GitHub Project board to prioritise work. Notes from these meetings, and from other ceremonies, should be added as comments on the relevant issue or pull request. The Project item should link to those discussions so that the board and issue history provide a complete record.
+
 ## Async Updates & Decision Logging
 
 All substantial design or process decisions are documented in Architecture Decision Records (ADRs) stored under `docs/3_Architecture & Design`. When a discussion in Slack or a meeting leads to a new decision, a short note with a link to the relevant ADR or issue is posted in the meeting thread.

--- a/tasks_startup.md
+++ b/tasks_startup.md
@@ -44,7 +44,7 @@ This document lists the tasks required to set up the repository and project on G
 
 - [ ] **Use GitHub issues and PRs as the canonical communication channel**
   - [x] Track tasks and decisions in issues and keep discussions in PRs for auditability.
-  - [ ] Use GitHub Projects for backlog grooming and link meeting notes to issues or PRs.
+  - [x] Use GitHub Projects for backlog grooming and link meeting notes to issues or PRs.
 
 - [ ] **Plan future work**
   - [ ] After completing the above tasks, create a new robust, comprehensive, and precise task list outlining the next steps for the project.


### PR DESCRIPTION
## Summary
- document using GitHub Projects for backlog grooming
- track meeting notes in issues/PRs
- mark backlog grooming task complete

## Testing
- `pre-commit run --files "docs/6_Dev Env & Collaboration/4_Communication & Meeting Cadence Plan/communication-plan.md" tasks_startup.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876d8fda7c8832cbb7c3dae4f655c12