### PR TITLE
Fix broken doc links and update docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,25 +1,45 @@
-name: Deploy Docs
+name: Deploy MkDocs with GitHub Pages dependencies preinstalled
 
 on:
   push:
-    branches: [main]
+    branches: ["main"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
-  build-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: |
-          pip install mkdocs mkdocs-material
-      - name: Build documentation
-        run: mkdocs build --strict
+        run: pip install mkdocs mkdocs-material
+      - name: Build with MkDocs
+        run: mkdocs build --strict --site-dir ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/spec/2_Requirements/1_Functional Spec or User-Story Backlog/functional_spec_protocol_ingestion.md
+++ b/docs/spec/2_Requirements/1_Functional Spec or User-Story Backlog/functional_spec_protocol_ingestion.md
@@ -1,7 +1,8 @@
 # Functional Specification – Protocol Ingestion & Information Extraction
+<a id="functional-spec-protocol-ingestion"></a>
 
 This specification expands on requirements in the
-[**CDISC CRF Generation Technical Plan**](../../CDISC%20CRF%20Generation%20Technical%20Plan_.md).
+[**CDISC CRF Generation Technical Plan**](../../technical-plan.md).
 
 > **Context & Goals**  
 > The Protocol Ingestion & Information Extraction (PIIE) feature automates the conversion of heterogeneous study‑protocol documents (DOCX, PDF, XML) into a validated **Study Requirements JSON** that downstream components (mapping, CRF generation, validation) consume.  

--- a/docs/spec/3_Architecture & Design/3_API Contract & Versioning Policy/api-contract-cli-wrapper.md
+++ b/docs/spec/3_Architecture & Design/3_API Contract & Versioning Policy/api-contract-cli-wrapper.md
@@ -1,6 +1,6 @@
 # API Contract – CLI Wrapper
 
-This service exposes a thin HTTP interface used by the command-line client. It mirrors the gateway policies from the [Technical Plan](../../CDISC%20CRF%20Generation%20Technical%20Plan_.md).
+This service exposes a thin HTTP interface used by the command-line client. It mirrors the gateway policies from the [Technical Plan](../../technical-plan.md).
 
 ## OpenAPI 3.1 Stub
 ```yaml

--- a/docs/spec/3_Architecture & Design/3_API Contract & Versioning Policy/api-contract-fastapi-gateway.md
+++ b/docs/spec/3_Architecture & Design/3_API Contract & Versioning Policy/api-contract-fastapi-gateway.md
@@ -1,6 +1,6 @@
 # API Contract – FastAPI Gateway
 
-This contract defines the public REST endpoints exposed by the FastAPI gateway component. It aligns with the principles outlined in the [CDISC CRF Generation Technical Plan](../../CDISC%20CRF%20Generation%20Technical%20Plan_.md).
+This contract defines the public REST endpoints exposed by the FastAPI gateway component. It aligns with the principles outlined in the [CDISC CRF Generation Technical Plan](../../technical-plan.md).
 
 ## OpenAPI 3.1 Stub
 ```yaml

--- a/docs/spec/3_Architecture & Design/3_API Contract & Versioning Policy/api-contract-mapping-generation.md
+++ b/docs/spec/3_Architecture & Design/3_API Contract & Versioning Policy/api-contract-mapping-generation.md
@@ -1,6 +1,6 @@
 # API Contract – Mapping Generation Service
 
-This microservice converts extracted study requirements into CDISC-compliant CRF artefacts. Design principles follow the [Technical Plan](../../CDISC%20CRF%20Generation%20Technical%20Plan_.md).
+This microservice converts extracted study requirements into CDISC-compliant CRF artefacts. Design principles follow the [Technical Plan](../../technical-plan.md).
 
 ## OpenAPI 3.1 Stub
 ```yaml

--- a/docs/spec/3_Architecture & Design/3_API Contract & Versioning Policy/api-contract-nlp-extraction.md
+++ b/docs/spec/3_Architecture & Design/3_API Contract & Versioning Policy/api-contract-nlp-extraction.md
@@ -1,6 +1,6 @@
 # API Contract – NLP Extraction Service
 
-The NLP service extracts entities from protocol text. Contracts comply with the [Technical Plan](../../CDISC%20CRF%20Generation%20Technical%20Plan_.md).
+The NLP service extracts entities from protocol text. Contracts comply with the [Technical Plan](../../technical-plan.md).
 
 ## OpenAPI 3.1 Stub
 ```yaml

--- a/docs/spec/3_Architecture & Design/3_API Contract & Versioning Policy/api-contract-validation.md
+++ b/docs/spec/3_Architecture & Design/3_API Contract & Versioning Policy/api-contract-validation.md
@@ -1,6 +1,6 @@
 # API Contract – Validation Service
 
-The validation microservice checks generated CRFs for standards compliance. It uses the interfaces defined in the [Technical Plan](../../CDISC%20CRF%20Generation%20Technical%20Plan_.md).
+The validation microservice checks generated CRFs for standards compliance. It uses the interfaces defined in the [Technical Plan](../../technical-plan.md).
 
 ## OpenAPI 3.1 Stub
 ```yaml

--- a/docs/spec/4_Planning & Risk/2_Risk Register & Mitigation Plan/risk-register.md
+++ b/docs/spec/4_Planning & Risk/2_Risk Register & Mitigation Plan/risk-register.md
@@ -1,6 +1,6 @@
 # Risk Register & Mitigation Plan
 
-The following register tracks key project risks derived from the [CDISC CRF Generation Technical Plan](../../CDISC%20CRF%20Generation%20Technical%20Plan_.md). Impact and Probability are scored from 1 (low) to 5 (high). Exposure is calculated as **Impact × Probability**. Severity icons are coded as:
+The following register tracks key project risks derived from the [CDISC CRF Generation Technical Plan](../../technical-plan.md). Impact and Probability are scored from 1 (low) to 5 (high). Exposure is calculated as **Impact × Probability**. Severity icons are coded as:
 
 - 🟥 Critical (16–25)
 - 🟧 High (10–15)

--- a/docs/spec/5_Quality & Ops/1_Test Strategy & Definition of Done/test-strategy.md
+++ b/docs/spec/5_Quality & Ops/1_Test Strategy & Definition of Done/test-strategy.md
@@ -1,6 +1,6 @@
 # Test Strategy & Definition of Done
 
-This strategy outlines how quality will be assured throughout development of the Protocol to CRF Generator. It is based on the approaches described in the [CDISC CRF Generation Technical Plan](../../CDISC%20CRF%20Generation%20Technical%20Plan_.md).
+This strategy outlines how quality will be assured throughout development of the Protocol to CRF Generator. It is based on the approaches described in the [CDISC CRF Generation Technical Plan](../../technical-plan.md).
 
 ## Objectives & Scope
 - Validate that all features work as specified and meet 21 CFR Part 11 compliance requirements.

--- a/docs/spec/5_Quality & Ops/2_Coding Standards + Style Guide/style-guide-python.md
+++ b/docs/spec/5_Quality & Ops/2_Coding Standards + Style Guide/style-guide-python.md
@@ -1,6 +1,6 @@
 # Python Coding Standards & Style Guide
 
-This guide defines the coding conventions for the Protocol to CRF Generator project. It summarises the practices set forth in the [CDISC CRF Generation Technical Plan](../../CDISC%20CRF%20Generation%20Technical%20Plan_.md) and expands on them with concrete examples.
+This guide defines the coding conventions for the Protocol to CRF Generator project. It summarises the practices set forth in the [CDISC CRF Generation Technical Plan](../../technical-plan.md) and expands on them with concrete examples.
 
 ## Formatting & Linting
 

--- a/docs/spec/5_Quality & Ops/3_CICD Pipeline Blueprint/cicd-blueprint.md
+++ b/docs/spec/5_Quality & Ops/3_CICD Pipeline Blueprint/cicd-blueprint.md
@@ -1,6 +1,6 @@
 # CI/CD Pipeline Blueprint
 
-This blueprint expands on Section 2.3 of the [CDISC CRF Generation Technical Plan](../../CDISC%20CRF%20Generation%20Technical%20Plan_.md). The pipeline is implemented with **GitHub Actions** and provides the auditable SDLC required for 21 CFR Part 11 compliance.
+This blueprint expands on Section 2.3 of the [CDISC CRF Generation Technical Plan](../../technical-plan.md). The pipeline is implemented with **GitHub Actions** and provides the auditable SDLC required for 21 CFR Part 11 compliance.
 
 ## Workflow Triggers
 - **Push / Pull Request** to `main` trigger the primary workflow defined in `.github/workflows/main.yml`.

--- a/docs/spec/5_Quality & Ops/4_Deployment & Rollback Runbook/runbook-deploy-rollback.md
+++ b/docs/spec/5_Quality & Ops/4_Deployment & Rollback Runbook/runbook-deploy-rollback.md
@@ -1,6 +1,6 @@
 # Deployment & Rollback Runbook
 
-This runbook outlines the standard procedure for deploying the Protocol to CRF Generator and reverting to a previous release if necessary. It complements the CI/CD workflow described in the [technical plan](../../CDISC%20CRF%20Generation%20Technical%20Plan_.md) and assumes Docker-based deployments managed via GitHub Actions.
+This runbook outlines the standard procedure for deploying the Protocol to CRF Generator and reverting to a previous release if necessary. It complements the CI/CD workflow described in the [technical plan](../../technical-plan.md) and assumes Docker-based deployments managed via GitHub Actions.
 
 ## Preconditions
 - A tagged release artifact is available in the container registry and on PyPI.

--- a/docs/spec/6_Dev Env & Collaboration/4_Communication & Meeting Cadence Plan/communication-plan.md
+++ b/docs/spec/6_Dev Env & Collaboration/4_Communication & Meeting Cadence Plan/communication-plan.md
@@ -1,6 +1,6 @@
 # Communication & Meeting Cadence Plan
 
-This plan defines how collaboration occurs on the Protocol to CRF Generator project. It summarises practices referenced in the [CDISC CRF Generation Technical Plan](../../CDISC%20CRF%20Generation%20Technical%20Plan_.md) and complements the stakeholder RACI register.
+This plan defines how collaboration occurs on the Protocol to CRF Generator project. It summarises practices referenced in the [CDISC CRF Generation Technical Plan](../../technical-plan.md) and complements the stakeholder RACI register.
 
 ## Communication Channels
 

--- a/docs/spec/7_Governance & Compliance/1_License & Third-Party Software Inventory/third-party-inventory.md
+++ b/docs/spec/7_Governance & Compliance/1_License & Third-Party Software Inventory/third-party-inventory.md
@@ -1,6 +1,6 @@
 # License & Third-Party Software Inventory
 
-This inventory lists the external dependencies referenced in the project and their associated licenses. The project itself is released under the Apache&nbsp;2.0 license as described in the [technical plan](../CDISC%20CRF%20Generation%20Technical%20Plan_.md). Keeping an accurate inventory helps ensure compliance with open‑source obligations and simplifies future audits.
+This inventory lists the external dependencies referenced in the project and their associated licenses. The project itself is released under the Apache&nbsp;2.0 license as described in the [technical plan](../technical-plan.md). Keeping an accurate inventory helps ensure compliance with open‑source obligations and simplifies future audits.
 
 | Package | Version | License | URL | Usage | Notes |
 | --- | --- | --- | --- | --- | --- |

--- a/docs/spec/7_Governance & Compliance/2_Security & Privacy Threat Model/threat-model.md
+++ b/docs/spec/7_Governance & Compliance/2_Security & Privacy Threat Model/threat-model.md
@@ -1,6 +1,6 @@
 # Security & Privacy Threat Model
 
-This document outlines potential security and privacy threats to the Protocol to CRF Generator using the **STRIDE** methodology. The analysis draws on controls described in the [technical plan](../CDISC%20CRF%20Generation%20Technical%20Plan_.md) such as CI-based static scanning and immutable audit logs.
+This document outlines potential security and privacy threats to the Protocol to CRF Generator using the **STRIDE** methodology. The analysis draws on controls described in the [technical plan](../../technical-plan.md) such as CI-based static scanning and immutable audit logs.
 
 ## System Overview
 


### PR DESCRIPTION
## Summary
- repair missing anchor link and remove broken links
- standardize references to `technical-plan.md`
- replace docs workflow with GitHub Pages deployment using MkDocs

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov --cov-fail-under=90`

------
https://chatgpt.com/codex/tasks/task_e_687913f1c438832c8b1ed4f5c306a992