### PR TITLE
Fix CI missing pytest-xdist and add badge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install deps
         run: |
           pip install -r requirements.txt
-          pip install pytest-cov
+          pip install pytest-cov pytest-xdist
       - name: Pytest
         run: pytest -n auto --cov --cov-fail-under=90
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Protocol to CRF Generator
 
-![CI](https://img.shields.io/badge/ci-github%20actions-blue?logo=github)
+[![CI](https://github.com/fderuiter/protocol_to_crf_generator/actions/workflows/main.yml/badge.svg)](https://github.com/fderuiter/protocol_to_crf_generator/actions/workflows/main.yml)
+[![Docs](https://github.com/fderuiter/protocol_to_crf_generator/actions/workflows/docs.yml/badge.svg)](https://github.com/fderuiter/protocol_to_crf_generator/actions/workflows/docs.yml)
+[![CLA](https://github.com/fderuiter/protocol_to_crf_generator/actions/workflows/cla.yml/badge.svg)](https://github.com/fderuiter/protocol_to_crf_generator/actions/workflows/cla.yml)
+[![CT Update](https://github.com/fderuiter/protocol_to_crf_generator/actions/workflows/ct-update.yml/badge.svg)](https://github.com/fderuiter/protocol_to_crf_generator/actions/workflows/ct-update.yml)
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue)
 
 A toolchain that converts clinical study protocols into CDISC‑compliant Case Report Form artefacts. See the [technical plan](docs/spec/technical-plan.md) for the full architecture and design rationale.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,9 @@ line-length = 88
 
 [tool.mypy]
 strict = true
+
+[tool.pytest.ini_options]
+addopts = "--cov=protocol_to_crf_generator"
+
+[tool.coverage.run]
+source = ["protocol_to_crf_generator"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ pre-commit
 ruff
 mypy
 pytest
+pytest-cov
+pytest-xdist


### PR DESCRIPTION
## Summary
- install pytest-xdist in CI and requirements
- update README with workflow badge
- add coverage config in pyproject

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_687919cb7ee4832c9ac476d9cef4cabf