### PR TITLE
Add markdown linting via script and CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,11 +19,13 @@ jobs:
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
-          pip install ruff mypy
+          pip install ruff mypy pymarkdownlnt
       - name: Ruff
         run: ruff check .
       - name: Mypy
         run: mypy --strict .
+      - name: Markdown Lint
+        run: python scripts/validate_markdown.py
 
   unit-test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,10 @@ repos:
     hooks:
       - id: mypy
         args: ["--strict"]
+  - repo: local
+    hooks:
+      - id: validate-markdown
+        name: validate-markdown
+        entry: python scripts/validate_markdown.py
+        language: python
+        types: [markdown]

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -33,4 +33,3 @@ Changes to supported standards correspond to semantic version bumps of the tool:
 
 - **MAJOR** release – adds support for or removes a major standard version.
 - **MINOR** release – adds a new backward-compatible standard such as an updated CT package.
-

--- a/README.md
+++ b/README.md
@@ -18,18 +18,23 @@ A toolchain that converts clinical study protocols into CDISC‑compliant Case R
 ## 3‑Step Setup
 
 1. Clone the repository
+
    ```bash
    git clone https://github.com/your-org/protocol-to-crf-generator.git
    cd protocol-to-crf-generator
    ```
+
 2. Install dependencies in a virtual environment
+
    ```bash
    python -m venv .venv
    source .venv/bin/activate
    pip install -r requirements.txt
    pre-commit install
    ```
+
 3. Run the CLI
+
    ```bash
    python -m protocol_to_crf_generator --help
    ```
@@ -43,9 +48,11 @@ A toolchain that converts clinical study protocols into CDISC‑compliant Case R
 ## Running Tests
 
 Execute the full suite with coverage:
+
 ```bash
 pytest -n auto --cov
 ```
+
 Tests should pass and coverage remain ≥90% as specified in the [test strategy](docs/spec/5_Quality%20&%20Ops/1_Test%20Strategy%20&%20Definition%20of%20Done/test-strategy.md).
 
 ## Contributing

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mypy
 pytest
 pytest-cov
 pytest-xdist
+pymarkdownlnt

--- a/scripts/validate_markdown.py
+++ b/scripts/validate_markdown.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import subprocess
+
+
+def main() -> int:
+    roots = [Path("."), Path("docs")]  # scan root markdown and top-level docs
+    files = []
+    for root in roots:
+        if root.exists():
+            files.extend(str(p) for p in root.glob("*.md"))
+    result = subprocess.run(
+        [
+            "pymarkdown",
+            "-d",
+            "MD013,MD022,MD025,MD032,MD033,MD007,MD012,MD041",
+            "scan",
+            *files,
+        ]
+    )
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a markdown validation script using `pymarkdown`
- include the script in pre-commit configuration
- add markdown lint step to the CI workflow
- ensure README code fences have surrounding blank lines
- trim trailing blank line in GOVERNANCE
- document `pymarkdownlnt` in requirements

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_6879341f45d4832cb2e1c3be0765244f