### PR TITLE
Add data-management prompt templates

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,3 +3,5 @@
 Welcome to the documentation for the Protocol to CRF Generator project. This tool converts clinical study protocols into CDISC-compliant Case Report Form artefacts.
 
 The full documentation set, including design specifications and requirements, is organised under the `spec` folder. See the [Documentation Table of Contents](spec/table-of-contents.md) for an overview of all available documents.
+
+Prompt templates for common data-management scenarios are provided in the [prompt_templates](prompt_templates) directory.

--- a/docs/prompt_templates/future_proof_architecture_blueprint.md
+++ b/docs/prompt_templates/future_proof_architecture_blueprint.md
@@ -1,0 +1,18 @@
+# Future-Proof Data-Architecture Blueprint
+
+Assume the role of an enterprise data-architect advisor.
+
+## Scenario
+- Current stack: on-prem SQL Server + nightly ETL to S3.
+- Forecast: 10× data growth over 18 months; need low-latency ML-serving.
+- Budget: $250 k capex + $6 k/mo opex.
+
+## Deliverables
+1. Compare at least 3 target architectures (lakehouse on Databricks, Snowflake with Iceberg tables, open-source Delta + DuckDB, etc.).
+2. For each, break down: storage layer, compute engine, governance tooling, estimated 3-year TCO.
+3. Recommend the best fit and justify with a decision matrix (criteria: scalability, cost, team skill alignment, vendor lock-in).
+4. List the first five migration milestones and rough duration.
+5. End with "Any questions?" if uncertainties remain.
+
+## Output format
+Decision matrix in Markdown, followed by a Gantt-style milestone table.

--- a/docs/prompt_templates/regulatory_gap_analysis.md
+++ b/docs/prompt_templates/regulatory_gap_analysis.md
@@ -1,0 +1,20 @@
+# Regulatory Data-Governance Gap Analysis
+
+You are the Chief Data Officer for a mid-size healthcare provider.
+
+## Context
+- Current data-governance policy excerpt (pasted below).
+- Target regulation: GDPR Art. 5 & EU AI Act Title IV.
+- Objective: find compliance gaps and draft a remediation roadmap.
+
+## Instructions
+1. Parse the policy and map each clause to the matching regulation article.
+2. Flag any partial or missing coverage.
+3. Rate the risk severity (High/Med/Low) and business impact.
+4. Recommend the top 5 remediation actions, ordered by risk-reduction ROI.
+5. Ask clarifying questions if policy details are insufficient.
+
+## Output format
+| Regulation article | Current coverage | Gap description | Risk | Recommended fix |
+|--------------------|------------------|-----------------|------|-----------------|
+*(fill the table, then provide a numbered action list)*

--- a/docs/prompt_templates/unified_data_cleansing.md
+++ b/docs/prompt_templates/unified_data_cleansing.md
@@ -1,0 +1,25 @@
+# Unified Data Cleansing & Consolidation
+
+You are a senior data engineer.
+
+## Context
+- Source-1: 2024-Q4 e-commerce CSV (schema below)
+- Source-2: CRM export (JSON)
+- Goal: build a single, analysis-ready table by close of business.
+
+## Task
+1. Identify schema mismatches, missing values, and outliers.
+2. Propose normalization rules (naming, data types, units, time-zones).
+3. Generate Python-pandas pseudocode for:
+   a. loading both sources,
+   b. applying the rules,
+   c. returning a consolidated DataFrame.
+4. List any assumptions; ask clarifying questions if something is ambiguous.
+
+## Output format
+Use fenced Markdown blocks:
+```python
+# step-by-step pseudocode here
+```
+
+Follow with a bullet list of remaining open questions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,3 +19,7 @@ nav:
   - Technical Plan: spec/technical-plan.md
   - Design: spec/design.md
   - Requirements: spec/requirements.md
+  - Prompt Templates:
+      - Unified Cleansing: prompt_templates/unified_data_cleansing.md
+      - Governance Gap Analysis: prompt_templates/regulatory_gap_analysis.md
+      - Architecture Blueprint: prompt_templates/future_proof_architecture_blueprint.md


### PR DESCRIPTION
## Summary
- add prompt templates for data cleansing, governance gap analysis and future-proof architecture
- link to new prompts in the docs index
- include pages in MkDocs navigation

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_687971819ee0832c8945b3bf1a51a954