### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/TASKS.md
+++ b/TASKS.md
@@ -189,7 +189,7 @@ instructions: |
 id: 2025-07-16-009
 phase: M0
 title: "Enable Dependabot for dependencies"
-status: TODO
+status: DONE
 priority: P2
 owner: ai
 depends_on:


### PR DESCRIPTION
## Summary
- add GitHub Dependabot configuration to keep actions and pip requirements up to date
- mark dependabot task as done

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_687ee512e2f4832c8da0eebc768b0614