### PR TITLE
Implement DOCX importer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
     hooks:
       - id: mypy
         args: ["--strict"]
+        additional_dependencies: ["pydantic"]
   - repo: local
     hooks:
       - id: validate-markdown

--- a/TASKS.md
+++ b/TASKS.md
@@ -263,7 +263,7 @@ instructions: |
 id: 2025-07-17-002
 phase: M1
 title: "Create DOCX importer with table extraction"
-status: TODO
+status: DONE
 priority: P0
 owner: ai
 depends_on:

--- a/protocol_to_crf_generator/ingestion/__init__.py
+++ b/protocol_to_crf_generator/ingestion/__init__.py
@@ -1,0 +1,5 @@
+"""Ingestion utilities."""
+
+from .docx_importer import load_docx
+
+__all__ = ["load_docx"]

--- a/protocol_to_crf_generator/ingestion/docx_importer.py
+++ b/protocol_to_crf_generator/ingestion/docx_importer.py
@@ -1,0 +1,45 @@
+"""DOCX importer extracting text and tables."""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+import csv
+
+from docx import Document
+
+
+def load_docx(path: Path) -> tuple[str, list[str]]:
+    """Load a .docx file and extract text and tables.
+
+    Parameters
+    ----------
+    path:
+        Path to the DOCX file.
+
+    Returns
+    -------
+    tuple[str, list[str]]
+        A tuple containing the document text and a list of tables as CSV strings.
+
+    Raises
+    ------
+    ValueError
+        If the supplied path does not end with ``.docx``.
+    """
+    if path.suffix.lower() != ".docx":
+        raise ValueError("Unsupported file type")
+
+    doc = Document(path)
+    text = "\n".join(paragraph.text for paragraph in doc.paragraphs)
+
+    tables: list[str] = []
+    for table in doc.tables:
+        buffer = StringIO()
+        writer = csv.writer(buffer)
+        for row in table.rows:
+            writer.writerow([cell.text.replace("\n", " ").strip() for cell in row.cells])
+        tables.append(buffer.getvalue().replace("\r\n", "\n").strip())
+        buffer.close()
+
+    return text, tables

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytest-cov
 pytest-xdist
 pymarkdownlnt
 pydantic
+python-docx

--- a/tests/test_docx_importer.py
+++ b/tests/test_docx_importer.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from protocol_to_crf_generator.ingestion import load_docx
+
+from docx import Document
+
+
+def _create_sample_docx(path: Path) -> None:
+    doc = Document()
+    doc.add_paragraph("Protocol Title")
+    table = doc.add_table(rows=2, cols=2)
+    table.rows[0].cells[0].text = "Header1"
+    table.rows[0].cells[1].text = "Header2"
+    table.rows[1].cells[0].text = "Value1"
+    table.rows[1].cells[1].text = "Value2"
+    doc.save(path)
+
+
+def test_load_docx(tmp_path: Path) -> None:
+    file_path = tmp_path / "sample.docx"
+    _create_sample_docx(file_path)
+    text, tables = load_docx(file_path)
+    assert "Protocol Title" in text
+    assert tables == ["Header1,Header2\nValue1,Value2"]
+
+
+def test_invalid_extension(tmp_path: Path) -> None:
+    file_path = tmp_path / "sample.txt"
+    file_path.write_text("not a docx")
+    try:
+        load_docx(file_path)
+    except ValueError:
+        pass
+    else:
+        assert False, "Expected ValueError"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,7 +29,7 @@ def test_study_protocol_ir_valid() -> None:
 
 def test_validation_error() -> None:
     with pytest.raises(ValidationError):
-        protocol.DataCollectionRequirement(
+        protocol.DataCollectionRequirement(  # type: ignore[call-arg]
             visit_name="Screening",
             assessment_name="ECG",
             provenance=protocol.Provenance(source_format="docx", source_identifier="prot.docx"),
@@ -40,5 +40,5 @@ def test_validation_error() -> None:
             protocol_id="P123",
             protocol_title="Example Study",
             version="1.0",
-            requirements=[{"not": "a requirement"}],
+            requirements=[{"not": "a requirement"}],  # type: ignore[list-item]
         )


### PR DESCRIPTION
## Summary
- create ingestion package and implement `load_docx`
- add unit tests for DOCX importer
- install python-docx and update pre-commit config
- mark task 2025-07-17-002 as DONE

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov --cov-fail-under=90`

------
https://chatgpt.com/codex/tasks/task_e_687eebf52078832c9f20cfb8d077ec8c