### PR TITLE
Implement IR storage with manifest

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -327,7 +327,7 @@ instructions: |
 id: 2025-07-17-004
 phase: M1
 title: "Persist StudyProtocolIR JSON with hash manifest"
-status: TODO
+status: DONE
 priority: P0
 owner: ai
 depends_on:

--- a/protocol_to_crf_generator/nlp/extract.py
+++ b/protocol_to_crf_generator/nlp/extract.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Rule-based NLP extraction using spaCy."""
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import List, Optional

--- a/protocol_to_crf_generator/persistence/__init__.py
+++ b/protocol_to_crf_generator/persistence/__init__.py
@@ -1,0 +1,5 @@
+"""Persistence utilities."""
+
+from .storage import save_ir
+
+__all__ = ["save_ir"]

--- a/protocol_to_crf_generator/persistence/storage.py
+++ b/protocol_to_crf_generator/persistence/storage.py
@@ -1,0 +1,75 @@
+"""Persistence layer for StudyProtocolIR objects."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from protocol_to_crf_generator.models.protocol import StudyProtocolIR
+
+
+DATA_DIR = Path("data")
+
+
+def _to_canonical_json(data: Any) -> str:
+    """Return canonical JSON per RFC 8785."""
+
+    def default(obj: Any) -> Any:
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        raise TypeError(f"Type {type(obj)} not serializable")
+
+    return json.dumps(
+        data,
+        default=default,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+def save_ir(ir: StudyProtocolIR, directory: Path | None = None) -> Path:
+    """Save the IR to disk and update the manifest.
+
+    Parameters
+    ----------
+    ir:
+        Instance to persist.
+    directory:
+        Optional base directory. Defaults to ``data``.
+
+    Returns
+    -------
+    Path
+        Path to the saved JSON file.
+    """
+
+    directory = directory or DATA_DIR
+    directory.mkdir(parents=True, exist_ok=True)
+
+    data = ir.model_dump() if hasattr(ir, "model_dump") else ir.dict()
+    json_text = _to_canonical_json(data)
+
+    timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    filename = f"{ir.protocol_id}_{timestamp}.json"
+    file_path = directory / filename
+    file_path.write_text(json_text, encoding="utf-8")
+
+    digest = hashlib.sha256(json_text.encode("utf-8")).hexdigest()
+
+    manifest_path = directory / "manifest.csv"
+    write_header = not manifest_path.exists()
+    with manifest_path.open("a", newline="") as fh:
+        writer = csv.writer(fh)
+        if write_header:
+            writer.writerow(["filename", "sha256", "timestamp"])
+        writer.writerow([filename, digest, timestamp])
+
+    return file_path
+
+
+__all__ = ["save_ir"]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+from pathlib import Path
+import hashlib
+import json
+
+from protocol_to_crf_generator.models import protocol
+from protocol_to_crf_generator.persistence import save_ir
+
+
+def _sample_ir() -> protocol.StudyProtocolIR:
+    return protocol.StudyProtocolIR(
+        protocol_id="P1",
+        protocol_title="Test",
+        version="1.0",
+        created_at=datetime(2025, 1, 1, 12, 0, 0),
+        requirements=[
+            protocol.DataCollectionRequirement(
+                requirement_id="R1",
+                visit_name="Screening",
+                assessment_name="ECG",
+                provenance=protocol.Provenance(
+                    source_format="docx",
+                    source_identifier="p.docx",
+                ),
+            )
+        ],
+    )
+
+
+def test_save_ir(tmp_path: Path) -> None:
+    ir = _sample_ir()
+    path = save_ir(ir, tmp_path)
+    assert path.exists()
+    data = ir.model_dump() if hasattr(ir, "model_dump") else ir.dict()
+    expected_json = json.dumps(
+        data,
+        default=lambda o: o.isoformat() if isinstance(o, datetime) else o,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    assert path.read_text(encoding="utf-8") == expected_json
+    manifest = (tmp_path / "manifest.csv").read_text(encoding="utf-8").splitlines()
+    header, row = manifest
+    assert header == "filename,sha256,timestamp"
+    filename, digest, timestamp = row.split(",")
+    assert filename == path.name
+    assert digest == hashlib.sha256(expected_json.encode("utf-8")).hexdigest()
+    assert timestamp


### PR DESCRIPTION
## Summary
- implement canonical JSON persistence with manifest
- add tests for storage logic
- fix module docstring ordering for ruff
- mark task 2025-07-17-004 as DONE

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_687ef0150f98832cbe4efa543f55f2d3