### PR TITLE
[2025-07-17-006] implement audit logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: mypy
         args: ["--strict"]
-        additional_dependencies: ["pydantic", "spacy", "python-docx"]
+        additional_dependencies: ["pydantic", "spacy", "python-docx", "fastapi"]
   - repo: local
     hooks:
       - id: validate-markdown

--- a/TASKS.md
+++ b/TASKS.md
@@ -391,7 +391,7 @@ instructions: |
 id: 2025-07-17-006
 phase: M1
 title: "Record structured audit logs to SQLite"
-status: TODO
+status: DONE
 priority: P1
 owner: ai
 depends_on:

--- a/protocol_to_crf_generator/audit/__init__.py
+++ b/protocol_to_crf_generator/audit/__init__.py
@@ -1,0 +1,7 @@
+"""Audit logging utilities."""
+
+from __future__ import annotations
+
+from .logging import configure_logging, SQLiteHandler
+
+__all__ = ["configure_logging", "SQLiteHandler"]

--- a/protocol_to_crf_generator/audit/logging.py
+++ b/protocol_to_crf_generator/audit/logging.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+
+AUDIT_DB = Path("audit_log.sqlite")
+
+
+class SQLiteHandler(logging.Handler):
+    """Logging handler that writes structured entries to SQLite."""
+
+    def __init__(self, db_path: Path | str = AUDIT_DB) -> None:
+        super().__init__()
+        self.db_path = Path(db_path)
+        self._ensure_table()
+
+    def _ensure_table(self) -> None:
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS AuditLog (timestamp TEXT, level TEXT, trace_id TEXT, message TEXT)"
+        )
+        conn.commit()
+        conn.close()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        entry_time = datetime.utcfromtimestamp(record.created).isoformat()
+        trace_id = getattr(record, "trace_id", "")
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            "INSERT INTO AuditLog (timestamp, level, trace_id, message) VALUES (?, ?, ?, ?)",
+            (entry_time, record.levelname, trace_id, record.getMessage()),
+        )
+        conn.commit()
+        conn.close()
+
+
+def configure_logging(db_path: Path | str = AUDIT_DB) -> logging.Logger:
+    """Return a logger configured to write JSON records to SQLite."""
+    logger = logging.getLogger("audit")
+    logger.setLevel(logging.INFO)
+    if not any(isinstance(h, SQLiteHandler) for h in logger.handlers):
+        logger.addHandler(SQLiteHandler(db_path))
+    return logger
+
+
+__all__ = ["configure_logging", "SQLiteHandler", "AUDIT_DB"]

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from protocol_to_crf_generator.audit.logging import configure_logging
+
+
+def test_audit_log_entry(tmp_path: Path) -> None:
+    db_file = tmp_path / "audit.sqlite"
+    logger = configure_logging(db_file)
+    logger.error("failure", extra={"trace_id": "t123"})
+
+    conn = sqlite3.connect(db_file)
+    row = conn.execute("SELECT level, trace_id, message FROM AuditLog").fetchone()
+    conn.close()
+
+    assert row == ("ERROR", "t123", "failure")


### PR DESCRIPTION
## Summary
- add audit logging package with SQLite handler
- test logging integration with SQLite
- configure mypy pre-commit hook to include fastapi
- mark task 2025-07-17-006 as DONE

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov --cov-fail-under=90`

------
https://chatgpt.com/codex/tasks/task_e_687ef3a422c0832cae90a595ee010981