### PR TITLE
Add FastAPI gateway with ingest and health endpoints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: mypy
         args: ["--strict"]
-        additional_dependencies: ["pydantic", "spacy", "python-docx"]
+        additional_dependencies: ["pydantic", "spacy", "python-docx", "fastapi", "httpx"]
   - repo: local
     hooks:
       - id: validate-markdown

--- a/TASKS.md
+++ b/TASKS.md
@@ -359,7 +359,7 @@ instructions: |
 id: 2025-07-17-005
 phase: M1
 title: "Add FastAPI gateway with /ingest and /health endpoints"
-status: TODO
+status: DONE
 priority: P0
 owner: ai
 depends_on:

--- a/protocol_to_crf_generator/api/__init__.py
+++ b/protocol_to_crf_generator/api/__init__.py
@@ -1,0 +1,2 @@
+"""API package providing FastAPI endpoints."""
+

--- a/protocol_to_crf_generator/api/main.py
+++ b/protocol_to_crf_generator/api/main.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import base64
+import uuid
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from fastapi import FastAPI, HTTPException, status
+from pydantic import BaseModel
+
+from protocol_to_crf_generator.ingestion import load_docx
+from protocol_to_crf_generator.nlp.extract import extract_entities
+from protocol_to_crf_generator.models.protocol import (
+    DataCollectionRequirement,
+    Provenance,
+    StudyProtocolIR,
+)
+from protocol_to_crf_generator.persistence import save_ir
+
+
+app = FastAPI(title="Protocol to CRF Generator")
+
+
+class ProtocolInput(BaseModel):
+    """Input document for ingestion."""
+
+    filename: str
+    content: str
+
+
+class JobStatus(BaseModel):
+    """Status returned when a job is accepted."""
+
+    job_id: str
+    state: str
+
+
+@app.post("/ingest", status_code=status.HTTP_202_ACCEPTED, response_model=JobStatus)
+def ingest(input_data: ProtocolInput) -> JobStatus:
+    """Ingest a protocol document synchronously."""
+
+    try:
+        binary = base64.b64decode(input_data.content)
+    except (base64.binascii.Error, ValueError) as exc:  # pragma: no cover - invalid base64
+        raise HTTPException(status_code=400, detail="Invalid content encoding") from exc
+
+    with NamedTemporaryFile(suffix=Path(input_data.filename).suffix) as tmp:
+        tmp.write(binary)
+        tmp.flush()
+        text, _tables = load_docx(Path(tmp.name))
+
+    provenance = Provenance(source_format="docx", source_identifier=input_data.filename)
+    entities = extract_entities(text, provenance)
+
+    requirements = [
+        DataCollectionRequirement(
+            requirement_id=str(i),
+            visit_name=e.text if e.label == "VISIT" else "",
+            assessment_name=e.text if e.label == "ASSESSMENT" else "",
+            provenance=e.provenance,
+        )
+        for i, e in enumerate(entities)
+    ]
+
+    ir = StudyProtocolIR(
+        protocol_id=Path(input_data.filename).stem,
+        protocol_title=input_data.filename,
+        version="1.0",
+        requirements=requirements,
+    )
+    save_ir(ir)
+
+    return JobStatus(job_id=str(uuid.uuid4()), state="accepted")
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Return basic service status."""
+
+    return {"status": "ok"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ pymarkdownlnt
 pydantic
 python-docx
 spacy
+fastapi
+httpx

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from docx import Document
+
+from protocol_to_crf_generator.api.main import app
+from protocol_to_crf_generator.persistence import storage
+
+
+def _create_docx(path: Path) -> None:
+    doc = Document()
+    doc.add_paragraph("Protocol Title")
+    doc.save(str(path))
+
+
+def test_health_endpoint() -> None:
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_ingest_endpoint(tmp_path: Path, monkeypatch) -> None:
+    file_path = tmp_path / "sample.docx"
+    _create_docx(file_path)
+    content = base64.b64encode(file_path.read_bytes()).decode()
+
+    monkeypatch.setattr(storage, "DATA_DIR", tmp_path)
+
+    client = TestClient(app)
+    response = client.post(
+        "/ingest",
+        json={"filename": "sample.docx", "content": content},
+    )
+
+    assert response.status_code == 202
+    data = response.json()
+    assert data["state"] == "accepted"
+    assert data["job_id"]
+    # ensure IR was written
+    assert any(p.suffix == ".json" for p in tmp_path.iterdir())


### PR DESCRIPTION
## Summary
- implement FastAPI app with `/ingest` and `/health`
- provide tests for the API
- update requirements and pre-commit config
- mark task 2025-07-17-005 DONE

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_687ef939e070832cabb617b6220df171