### PR TITLE
Add CLI ingest subcommand

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -482,7 +482,7 @@ instructions: |
 id: 2025-07-17-009
 phase: M1
 title: "Extend CLI with ingest command"
-status: TODO
+status: DONE
 priority: P1
 owner: ai
 depends_on:

--- a/protocol_to_crf_generator/__main__.py
+++ b/protocol_to_crf_generator/__main__.py
@@ -1,15 +1,55 @@
-"""Simple CLI entry point."""
+"""Command line interface for the package."""
+
+from __future__ import annotations
 
 import argparse
+import base64
+from pathlib import Path
+
+import httpx
 
 from . import __version__
+
+
+def _cmd_ingest(file: Path, url: str) -> None:
+    """Upload ``file`` to the API ``url``.
+
+    Parameters
+    ----------
+    file:
+        Path to the protocol document.
+    url:
+        Base URL of the running API service.
+    """
+
+    content = base64.b64encode(file.read_bytes()).decode()
+    payload = {"filename": file.name, "content": content}
+
+    try:
+        response = httpx.post(f"{url.rstrip('/')}/ingest", json=payload, timeout=10)
+        response.raise_for_status()
+    except httpx.HTTPError as exc:  # pragma: no cover - network failures
+        print(f"Error: {exc}")
+        raise SystemExit(1) from exc
+
+    data = response.json()
+    print(f"Job {data['job_id']} {data['state']}")
 
 
 def main(args: list[str] | None = None) -> None:
     """Run the command line interface."""
     parser = argparse.ArgumentParser(description="Protocol to CRF Generator")
     parser.add_argument("--version", action="version", version=__version__)
-    parser.parse_args(args)
+
+    subparsers = parser.add_subparsers(dest="command")
+    ingest_parser = subparsers.add_parser("ingest", help="Upload a protocol")
+    ingest_parser.add_argument("file", type=Path)
+    ingest_parser.add_argument("--url", default="http://localhost:8000")
+
+    ns = parser.parse_args(args)
+
+    if ns.command == "ingest":
+        _cmd_ingest(ns.file, ns.url)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/protocol_to_crf_generator/api/main.py
+++ b/protocol_to_crf_generator/api/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+from binascii import Error as BinasciiError
 import uuid
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -41,7 +42,7 @@ def ingest(input_data: ProtocolInput) -> JobStatus:
 
     try:
         binary = base64.b64decode(input_data.content)
-    except (base64.binascii.Error, ValueError) as exc:  # pragma: no cover - invalid base64
+    except (BinasciiError, ValueError) as exc:  # pragma: no cover - invalid base64
         raise HTTPException(status_code=400, detail="Invalid content encoding") from exc
 
     with NamedTemporaryFile(suffix=Path(input_data.filename).suffix) as tmp:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 from docx import Document
+import pytest  # type: ignore
 
 from protocol_to_crf_generator.api.main import app
 from protocol_to_crf_generator.persistence import storage
@@ -23,7 +24,7 @@ def test_health_endpoint() -> None:
     assert response.json() == {"status": "ok"}
 
 
-def test_ingest_endpoint(tmp_path: Path, monkeypatch) -> None:
+def test_ingest_endpoint(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     file_path = tmp_path / "sample.docx"
     _create_docx(file_path)
     content = base64.b64encode(file_path.read_bytes()).decode()

--- a/tests/test_cli_ingest.py
+++ b/tests/test_cli_ingest.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from protocol_to_crf_generator.__main__ import main
+
+
+def test_cmd_ingest_posts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    file_path = tmp_path / "sample.docx"
+    file_path.write_text("dummy")
+
+    captured = {}
+
+    def fake_post(url: str, json: dict, timeout: int) -> SimpleNamespace:
+        captured["url"] = url
+        captured["json"] = json
+
+        return SimpleNamespace(
+            json=lambda: {"job_id": "42", "state": "accepted"},
+            raise_for_status=lambda: None,
+        )
+
+    monkeypatch.setattr("httpx.post", fake_post)
+
+    main(["ingest", str(file_path), "--url", "http://test"])
+    output = capsys.readouterr().out
+
+    assert captured["url"] == "http://test/ingest"
+    assert captured["json"]["filename"] == "sample.docx"
+    assert "Job 42 accepted" in output
+


### PR DESCRIPTION
## Summary
- implement `ingest` subcommand in CLI to upload DOCX files
- handle network errors gracefully
- mock HTTP call in new `test_cli_ingest`
- annotate `test_api` for mypy
- mark ingest CLI task done in `TASKS.md`

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_687efb1ad0a4832ca5f9a3fb842644dd