### PR TITLE
Implement audit logging to SQLite

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -391,7 +391,7 @@ instructions: |
 id: 2025-07-17-006
 phase: M1
 title: "Record structured audit logs to SQLite"
-status: TODO
+status: DONE
 priority: P1
 owner: ai
 depends_on:

--- a/protocol_to_crf_generator/audit/__init__.py
+++ b/protocol_to_crf_generator/audit/__init__.py
@@ -1,0 +1,5 @@
+"""Audit logging utilities."""
+
+from .logging import setup_audit_logger, SQLiteAuditHandler
+
+__all__ = ["setup_audit_logger", "SQLiteAuditHandler"]

--- a/protocol_to_crf_generator/audit/logging.py
+++ b/protocol_to_crf_generator/audit/logging.py
@@ -1,0 +1,55 @@
+import json
+import logging
+import sqlite3
+from pathlib import Path
+
+
+DB_PATH = Path("audit_log.sqlite")
+
+
+class SQLiteAuditHandler(logging.Handler):
+    """Logging handler writing JSON records to SQLite."""
+
+    def __init__(self, db_path: Path = DB_PATH) -> None:
+        super().__init__()
+        self.db_path = db_path
+        self._ensure_table()
+
+    def _ensure_table(self) -> None:
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.cursor()
+        cur.execute("CREATE TABLE IF NOT EXISTS AuditLog (entry TEXT)")
+        conn.commit()
+        conn.close()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        entry = json.dumps(
+            {
+                "level": record.levelname,
+                "message": record.getMessage(),
+                "trace_id": getattr(record, "trace_id", ""),
+            }
+        )
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.cursor()
+        cur.execute("INSERT INTO AuditLog (entry) VALUES (?)", (entry,))
+        conn.commit()
+        conn.close()
+
+
+def setup_audit_logger(db_path: Path | str | None = None) -> logging.Logger:
+    """Configure and return the audit logger."""
+    path = Path(db_path) if db_path is not None else DB_PATH
+    logger = logging.getLogger("protocol_to_crf_generator.audit")
+    logger.setLevel(logging.INFO)
+
+    # remove existing handlers of this type
+    for handler in list(logger.handlers):
+        if isinstance(handler, SQLiteAuditHandler):
+            logger.removeHandler(handler)
+
+    logger.addHandler(SQLiteAuditHandler(path))
+    return logger
+
+
+__all__ = ["setup_audit_logger", "SQLiteAuditHandler"]

--- a/tests/test_cli_ingest.py
+++ b/tests/test_cli_ingest.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, Dict
 
-import pytest
+import pytest  # type: ignore
 
 from protocol_to_crf_generator.__main__ import main
 
@@ -10,9 +11,9 @@ def test_cmd_ingest_posts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsy
     file_path = tmp_path / "sample.docx"
     file_path.write_text("dummy")
 
-    captured = {}
+    captured: Dict[str, Any] = {}
 
-    def fake_post(url: str, json: dict, timeout: int) -> SimpleNamespace:
+    def fake_post(url: str, json: Dict[str, Any], timeout: int) -> SimpleNamespace:
         captured["url"] = url
         captured["json"] = json
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,29 @@
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest  # type: ignore
+from fastapi.testclient import TestClient
+
+from protocol_to_crf_generator.api import main
+from protocol_to_crf_generator.audit import setup_audit_logger
+
+
+def test_error_written_to_audit_log(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db_path = tmp_path / "audit.sqlite"
+    logger = setup_audit_logger(db_path)
+    main.audit_logger = logger
+
+    client = TestClient(main.app)
+    response = client.post("/ingest", json={"filename": "bad.docx", "content": "!!!"})
+    assert response.status_code == 400
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT entry FROM AuditLog")
+    rows = [json.loads(row[0]) for row in cur.fetchall()]
+    conn.close()
+
+    error_rows = [r for r in rows if r["level"] == "ERROR"]
+    assert error_rows
+    assert error_rows[0]["trace_id"]


### PR DESCRIPTION
## Summary
- add audit logging module with SQLite handler
- integrate audit logger into API ingestion
- expand CLI ingest test types
- add tests for audit logging
- mark structured audit logging task DONE

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov=protocol_to_crf_generator --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_687f6e44d738832c8391be2821f2cebb