### PR TITLE
Fix CI dependency installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff mypy
+          pip install -r requirements.txt
       - name: Ruff
         run: ruff check .
       - name: Mypy
@@ -34,6 +34,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install pytest-cov pytest-xdist
+          pip install -e .
       - name: Pytest
         run: pytest -n auto --cov --cov-fail-under=90

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: mypy
         args: ["--strict"]
-        additional_dependencies: ["pydantic", "spacy", "python-docx", "fastapi", "httpx"]
+        additional_dependencies: ["pydantic", "spacy", "python-docx", "fastapi[test]", "httpx"]
   - repo: https://github.com/PyCQA/bandit
     rev: 1.8.6
     hooks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ pymarkdownlnt
 pydantic
 python-docx
 spacy
-fastapi
+ fastapi[test]
 httpx


### PR DESCRIPTION
## Summary
- install project dependencies for lint
- use editable install in unit tests
- include FastAPI test extras

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_687f885d793c832c848312917c7903de