### PR TITLE
Fix mypy job and clean test imports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements.txt
           pip install ruff mypy pymarkdownlnt
       - name: Ruff
         run: ruff check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: mypy
         args: ["--strict"]
-        additional_dependencies: ["pydantic", "spacy", "python-docx", "fastapi[test]", "httpx"]
+        additional_dependencies: ["pydantic", "spacy", "python-docx", "fastapi", "httpx", "pytest"]
   - repo: https://github.com/PyCQA/bandit
     rev: 1.8.6
     hooks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ pymarkdownlnt
 pydantic
 python-docx
 spacy
- fastapi[test]
+fastapi
+fastapi[test]
 httpx

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from fastapi.testclient import TestClient
 from docx import Document
-import pytest  # type: ignore
+import pytest
 
 from protocol_to_crf_generator.api.main import app
 from protocol_to_crf_generator.persistence import storage

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-import pytest  # type: ignore
+import pytest
 
 
 

--- a/tests/test_cli_ingest.py
+++ b/tests/test_cli_ingest.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict
 
-import pytest  # type: ignore
+import pytest
 
 from protocol_to_crf_generator.__main__ import main
 

--- a/tests/test_ct_update.py
+++ b/tests/test_ct_update.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-import pytest  # type: ignore
+import pytest
 
 from protocol_to_crf_generator import ct_update
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,7 +2,7 @@ import json
 import sqlite3
 from pathlib import Path
 
-import pytest  # type: ignore
+import pytest
 from fastapi.testclient import TestClient
 
 from protocol_to_crf_generator.api import main

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 from protocol_to_crf_generator.models import protocol
 from pydantic import ValidationError
-import pytest  # type: ignore
+import pytest
 
 
 def _requirement() -> protocol.DataCollectionRequirement:


### PR DESCRIPTION
## Summary
- install project dependencies for linting
- tweak pre-commit to include pytest
- remove unused `# type: ignore` comments
- list FastAPI in requirements

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_687f8b8c1e4c832ca57ff4af5c4307e1