### PR TITLE
Add mapping endpoint

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -422,7 +422,7 @@ instructions: |
 id: 2025-07-17-007
 phase: M1
 title: "Add mapping service stub and /map endpoint"
-status: TODO
+status: DONE
 priority: P1
 owner: ai
 depends_on:

--- a/protocol_to_crf_generator/api/main.py
+++ b/protocol_to_crf_generator/api/main.py
@@ -18,10 +18,12 @@ from protocol_to_crf_generator.models.protocol import (
 )
 from protocol_to_crf_generator.persistence import save_ir
 from protocol_to_crf_generator.audit import setup_audit_logger
+from protocol_to_crf_generator.api.mapping import router as mapping_router
 
 
 app = FastAPI(title="Protocol to CRF Generator")
 audit_logger = setup_audit_logger()
+app.include_router(mapping_router)
 
 
 class ProtocolInput(BaseModel):

--- a/protocol_to_crf_generator/api/mapping.py
+++ b/protocol_to_crf_generator/api/mapping.py
@@ -1,0 +1,33 @@
+"""Mapping service stub for the prototype."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+
+router = APIRouter()
+
+
+class MappingRequest(BaseModel):
+    """Request model for mapping an IR to CRF."""
+
+    ir_id: str
+
+
+class MappingResult(BaseModel):
+    """Result returned after mapping."""
+
+    crf_id: str
+
+
+@router.post("/map", response_model=MappingResult)
+def map_ir(payload: MappingRequest) -> MappingResult:
+    """Return a placeholder CRF identifier for the supplied IR."""
+
+    return MappingResult(crf_id=f"crf-{uuid.uuid4()}")
+
+
+__all__ = ["router", "MappingRequest", "MappingResult"]

--- a/tests/test_mapping.py
+++ b/tests/test_mapping.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+
+from protocol_to_crf_generator.api.main import app
+
+
+def test_map_endpoint_returns_crf_id() -> None:
+    client = TestClient(app)
+    response = client.post("/map", json={"ir_id": "123"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["crf_id"]


### PR DESCRIPTION
## Summary
- add mapping endpoint and tests
- include router in API app
- mark mapping task done

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_687fbf2e2fa8832caf6aaf0ac4df2932