### PR TITLE
Add validation service stub

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -452,7 +452,7 @@ instructions: |
 id: 2025-07-17-008
 phase: M1
 title: "Add validation service stub and /validate endpoint"
-status: TODO
+status: DONE
 priority: P1
 owner: ai
 depends_on:

--- a/protocol_to_crf_generator/api/main.py
+++ b/protocol_to_crf_generator/api/main.py
@@ -19,11 +19,13 @@ from protocol_to_crf_generator.models.protocol import (
 from protocol_to_crf_generator.persistence import save_ir
 from protocol_to_crf_generator.audit import setup_audit_logger
 from protocol_to_crf_generator.api.mapping import router as mapping_router
+from protocol_to_crf_generator.api.validation import router as validation_router
 
 
 app = FastAPI(title="Protocol to CRF Generator")
 audit_logger = setup_audit_logger()
 app.include_router(mapping_router)
+app.include_router(validation_router)
 
 
 class ProtocolInput(BaseModel):

--- a/protocol_to_crf_generator/api/validation.py
+++ b/protocol_to_crf_generator/api/validation.py
@@ -1,0 +1,31 @@
+"""Validation service stub for the prototype."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+
+router = APIRouter()
+
+
+class ValidationRequest(BaseModel):
+    """Request model for validation."""
+
+    crf_id: str
+
+
+class ValidationResult(BaseModel):
+    """Validation result returned by the service."""
+
+    status: str
+
+
+@router.post("/validate", response_model=ValidationResult)
+def validate_crf(payload: ValidationRequest) -> ValidationResult:
+    """Return a fixed validation status for the supplied CRF."""
+
+    return ValidationResult(status="valid")
+
+
+__all__ = ["router", "ValidationRequest", "ValidationResult"]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+
+from protocol_to_crf_generator.api.main import app
+
+
+def test_validate_endpoint_returns_status() -> None:
+    client = TestClient(app)
+    response = client.post("/validate", json={"crf_id": "123"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "valid"


### PR DESCRIPTION
## Summary
- add `/validate` endpoint router and include in API
- test `/validate` returns a stub status
- mark task 2025-07-17-008 as DONE

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov --cov-fail-under=90`

------
https://chatgpt.com/codex/tasks/task_e_687fd35a4ffc832c897c88ab227cb790