### PR TITLE
Update README with Docker usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,33 @@ A toolchain that converts clinical study protocols into CDISC‑compliant Case R
    python -m protocol_to_crf_generator --help
    ```
 
+## Running via Docker
+
+Build and start the API service:
+
+```bash
+docker build -t protocol-to-crf .
+docker run -p 8000:8000 protocol-to-crf
+```
+
+Alternatively use Docker Compose which starts auxiliary services:
+
+```bash
+docker compose up --build
+```
+
+The API is then available at `http://localhost:8000`.
+
+## CLI ingest example
+
+With the API running, upload a protocol document:
+
+```bash
+python -m protocol_to_crf_generator ingest sample.docx
+```
+
+The command prints the job identifier returned by `/ingest`.
+
 ## Common Commands
 
 - `pre-commit run --all-files` – lint, type-check and scan for security issues

--- a/TASKS.md
+++ b/TASKS.md
@@ -567,7 +567,7 @@ instructions: |
 id: 2025-07-17-012
 phase: M1
 title: "Update README with API and Docker usage"
-status: TODO
+status: DONE
 priority: P2
 owner: ai
 depends_on:


### PR DESCRIPTION
## Summary
- document how to run the service with Docker
- show CLI ingest command example
- mark README update task as DONE

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov=protocol_to_crf_generator --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_687fea8c8db0832c827ed7245cde1c71