### PR TITLE
Add terminology lookup cache

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -625,7 +625,7 @@ instructions: |
 id: 2025-07-17-014
 phase: M2
 title: "Cache controlled terminology lookups"
-status: TODO
+status: DONE
 priority: P1
 owner: ai
 depends_on:

--- a/protocol_to_crf_generator/api/mapping.py
+++ b/protocol_to_crf_generator/api/mapping.py
@@ -7,8 +7,22 @@ import uuid
 from fastapi import APIRouter
 from pydantic import BaseModel
 
+from protocol_to_crf_generator.ct_cache import CTCache
+
 
 router = APIRouter()
+
+
+TERMINOLOGY_DB = {"IR1": "Case Report Form"}
+
+
+def _fetch_term(code: str) -> str:
+    """Simulate a terminology lookup."""
+
+    return TERMINOLOGY_DB.get(code, "")
+
+
+_cache = CTCache(_fetch_term, maxsize=256)
 
 
 class MappingRequest(BaseModel):
@@ -27,6 +41,7 @@ class MappingResult(BaseModel):
 def map_ir(payload: MappingRequest) -> MappingResult:
     """Return a placeholder CRF identifier for the supplied IR."""
 
+    _cache.lookup(payload.ir_id)
     return MappingResult(crf_id=f"crf-{uuid.uuid4()}")
 
 

--- a/protocol_to_crf_generator/ct_cache.py
+++ b/protocol_to_crf_generator/ct_cache.py
@@ -1,0 +1,43 @@
+"""Simple in-memory LRU cache for terminology lookups."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Callable, Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class CTCache(Generic[T]):
+    """LRU cache storing the results of expensive lookups."""
+
+    def __init__(self, fetch_func: Callable[[str], T], maxsize: int = 128) -> None:
+        self.fetch_func = fetch_func
+        self.maxsize = maxsize
+        self._cache: OrderedDict[str, T] = OrderedDict()
+        self.hits = 0
+        self.misses = 0
+
+    def lookup(self, key: str) -> T:
+        """Return cached value for ``key`` or fetch and store it."""
+
+        if key in self._cache:
+            self.hits += 1
+            self._cache.move_to_end(key)
+            return self._cache[key]
+
+        self.misses += 1
+        value = self.fetch_func(key)
+        self._cache[key] = value
+        if len(self._cache) > self.maxsize:
+            self._cache.popitem(last=False)
+        return value
+
+    def hit_rate(self) -> float:
+        """Return cache hit rate as a float between 0 and 1."""
+
+        total = self.hits + self.misses
+        return (self.hits / total) if total else 0.0
+
+
+__all__ = ["CTCache"]

--- a/tests/test_ct_cache.py
+++ b/tests/test_ct_cache.py
@@ -1,0 +1,17 @@
+from protocol_to_crf_generator.ct_cache import CTCache
+
+
+def test_lru_cache_reduces_db_queries() -> None:
+    calls = {"count": 0}
+
+    def fetch(key: str) -> str:
+        calls["count"] += 1
+        return key.upper()
+
+    cache = CTCache(fetch, maxsize=8)
+
+    for _ in range(100):
+        assert cache.lookup("test") == "TEST"
+
+    assert calls["count"] == 1
+    assert cache.hit_rate() >= 0.9


### PR DESCRIPTION
## Summary
- implement a simple LRU cache for terminology lookups
- integrate the cache with the mapping service
- test cache hit rate
- mark the terminology cache task as complete

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov=protocol_to_crf_generator --cov-fail-under=90`

------
https://chatgpt.com/codex/tasks/task_e_687ff42cd3fc832cb6347eee288087d5