### PR TITLE
Implement rate limiting middleware

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       - id: mypy
         args: ["--strict"]
-        additional_dependencies: ["pydantic", "spacy", "python-docx", "fastapi", "httpx", "pytest", "locust"]
+        additional_dependencies: ["pydantic", "spacy", "python-docx", "fastapi", "httpx", "pytest", "locust", "slowapi"]
   - repo: https://github.com/PyCQA/bandit
     rev: 1.8.6
     hooks:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ docker compose up --build
 
 The API is then available at `http://localhost:8000`.
 
+## Configuration
+
+The rate limiter defaults to `5/minute` per IP address. Override this by setting
+the environment variable `RATE_LIMIT` before starting the API:
+
+```bash
+export RATE_LIMIT=10/minute
+docker compose up --build
+```
+
 ## CLI ingest example
 
 With the API running, upload a protocol document:

--- a/TASKS.md
+++ b/TASKS.md
@@ -655,7 +655,7 @@ instructions: |
 id: 2025-07-17-015
 phase: M2
 title: "Add API rate limiting middleware"
-status: TODO
+status: DONE
 priority: P0
 owner: ai
 depends_on:

--- a/protocol_to_crf_generator/api/main.py
+++ b/protocol_to_crf_generator/api/main.py
@@ -20,10 +20,12 @@ from protocol_to_crf_generator.persistence import save_ir
 from protocol_to_crf_generator.audit import setup_audit_logger
 from protocol_to_crf_generator.api.mapping import router as mapping_router
 from protocol_to_crf_generator.api.validation import router as validation_router
+from protocol_to_crf_generator.api.rate_limit import setup_rate_limiter
 
 
 app = FastAPI(title="Protocol to CRF Generator")
 audit_logger = setup_audit_logger()
+setup_rate_limiter(app)
 app.include_router(mapping_router)
 app.include_router(validation_router)
 

--- a/protocol_to_crf_generator/api/rate_limit.py
+++ b/protocol_to_crf_generator/api/rate_limit.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import os
+from fastapi import FastAPI
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
+from slowapi.util import get_remote_address
+
+DEFAULT_LIMIT = os.getenv("RATE_LIMIT", "5/minute")
+
+
+def setup_rate_limiter(app: FastAPI) -> Limiter:
+    """Configure rate limiting on the given FastAPI application."""
+
+    limiter = Limiter(key_func=get_remote_address, default_limits=[DEFAULT_LIMIT])
+    app.state.limiter = limiter
+    app.add_exception_handler(
+        RateLimitExceeded, _rate_limit_exceeded_handler  # type: ignore[arg-type]
+    )
+    app.add_middleware(SlowAPIMiddleware)
+    return limiter
+
+
+__all__ = ["setup_rate_limiter", "DEFAULT_LIMIT"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ fastapi
 fastapi[test]
 httpx
 locust
+slowapi

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,19 @@
+from importlib import reload
+
+from fastapi.testclient import TestClient
+
+import protocol_to_crf_generator.api.main as main
+import protocol_to_crf_generator.api.rate_limit as rate_limit
+
+
+def test_rate_limit_exceeded(monkeypatch):
+    monkeypatch.setenv("RATE_LIMIT", "2/minute")
+    reload(rate_limit)
+    reload(main)
+    client = TestClient(main.app)
+    assert client.get("/health").status_code == 200
+    assert client.get("/health").status_code == 200
+    response = client.get("/health")
+    assert response.status_code == 429
+
+

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,12 +1,13 @@
 from importlib import reload
 
 from fastapi.testclient import TestClient
+import pytest
 
 import protocol_to_crf_generator.api.main as main
 import protocol_to_crf_generator.api.rate_limit as rate_limit
 
 
-def test_rate_limit_exceeded(monkeypatch):
+def test_rate_limit_exceeded(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("RATE_LIMIT", "2/minute")
     reload(rate_limit)
     reload(main)


### PR DESCRIPTION
## Summary
- add slowapi dependency and configure for mypy
- add rate limiting middleware and tests
- document `RATE_LIMIT` env variable
- mark task 2025-07-17-015 as DONE

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_687ff7e2df00832c9e93cabf4fdcf3eb