### PR TITLE
Add ZAP scan workflow

### DIFF
--- a/.github/workflows/zap_scan.yml
+++ b/.github/workflows/zap_scan.yml
@@ -1,0 +1,17 @@
+name: OWASP ZAP Scan
+
+on:
+  schedule:
+    - cron: '0 1 * * 0'
+  workflow_dispatch:
+
+jobs:
+  zap-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ZAP Baseline Scan
+        uses: zaproxy/action-baseline@v0.11.0
+        with:
+          target: ${{ secrets.STAGING_URL }}
+          fail_action: true
+          cmd_options: '-a -m 3'

--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+audit_log.sqlite

--- a/TASKS.md
+++ b/TASKS.md
@@ -684,7 +684,7 @@ instructions: |
 id: 2025-07-17-016
 phase: M2
 title: "Integrate OWASP ZAP scan in CI"
-status: TODO
+status: DONE
 priority: P1
 owner: ai
 depends_on:


### PR DESCRIPTION
## Summary
- integrate OWASP ZAP scanning into CI
- ignore the generated audit log
- mark ZAP scan task as done

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_687fff14515c832c91d6711e144d2821