### PR TITLE
docs: add GitHub Models overview

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -36,7 +36,7 @@ instructions: |
 id: 2025-07-19-026
 phase: M1
 title: "Document GitHub Models integration"
-status: TODO
+status: DONE
 priority: P3
 owner: ai
 depends_on: []

--- a/TASKS.md
+++ b/TASKS.md
@@ -43,6 +43,7 @@ depends_on: []
 path:
   - docs/github_models.md
   - docs/prototyping_with_ai_models.md
+  - docs/evaluating_ai_models.md
   - docs/spec/1_Vision & Scope/1_Project Charter + Vision Statement/project_charter.md
   - docs/index.md
   - mkdocs.yml

--- a/TASKS.md
+++ b/TASKS.md
@@ -44,6 +44,7 @@ path:
   - docs/github_models.md
   - docs/prototyping_with_ai_models.md
   - docs/evaluating_ai_models.md
+  - docs/storing_prompts.md
   - docs/spec/1_Vision & Scope/1_Project Charter + Vision Statement/project_charter.md
   - docs/index.md
   - mkdocs.yml

--- a/TASKS.md
+++ b/TASKS.md
@@ -45,6 +45,7 @@ path:
   - docs/prototyping_with_ai_models.md
   - docs/evaluating_ai_models.md
   - docs/storing_prompts.md
+  - docs/integrating_ai_models.md
   - docs/spec/1_Vision & Scope/1_Project Charter + Vision Statement/project_charter.md
   - docs/index.md
   - mkdocs.yml

--- a/TASKS.md
+++ b/TASKS.md
@@ -34,7 +34,7 @@ instructions: |
 
 <!-- task:start -->
 id: 2025-07-19-026
-phase: M4
+phase: M1
 title: "Document GitHub Models integration"
 status: TODO
 priority: P3
@@ -42,6 +42,7 @@ owner: ai
 depends_on: []
 path:
   - docs/github_models.md
+  - docs/prototyping_with_ai_models.md
   - docs/spec/1_Vision & Scope/1_Project Charter + Vision Statement/project_charter.md
   - docs/index.md
   - mkdocs.yml

--- a/TASKS.md
+++ b/TASKS.md
@@ -33,6 +33,36 @@ instructions: |
 <!-- task:end -->
 
 <!-- task:start -->
+id: 2025-07-19-026
+phase: M4
+title: "Document GitHub Models integration"
+status: TODO
+priority: P3
+owner: ai
+depends_on: []
+path:
+  - docs/github_models.md
+  - docs/spec/1_Vision & Scope/1_Project Charter + Vision Statement/project_charter.md
+  - docs/index.md
+  - mkdocs.yml
+tests: []
+acceptance:
+  - "New documentation file summarises GitHub Models"
+  - "Project charter scope updated"
+  - "mkdocs navigation links to the new page"
+  - "All unit and integration tests pass with coverage ≥90%."
+  - "Linting, formatting and security scans report no errors of severity \"Critical\" or higher."
+  - "Documentation updated for new or changed features."
+  - "CI pipeline completes successfully including Docker image build."
+  - "Peer review approvals obtained."
+context: |
+  GitHub Models will be used for prompt iteration and evaluation. Documentation must capture capabilities and enablement instructions.
+instructions: |
+  - Create `docs/github_models.md` summarising overview, capabilities, enabling, comparisons and playground usage.
+  - Link to this page from `index.md` and add bullet to mkdocs navigation.
+  - Update project charter in-scope section with a GitHub Models bullet.
+<!-- task:end -->
+<!-- task:start -->
 id: 2025-07-16-002
 phase: M0
 title: "Seed project documentation and policies"

--- a/docs/evaluating_ai_models.md
+++ b/docs/evaluating_ai_models.md
@@ -1,0 +1,83 @@
+# Evaluating AI models
+
+Test and compare AI model outputs using evaluators and scoring metrics in GitHub Models.
+
+## Overview
+
+GitHub Models provides a simple evaluation workflow that helps developers compare large language models (LLMs), refine prompts, and make data-driven decisions within the GitHub platform. You can use GitHub Models to experiment with new features or validate model changes by analyzing performance, accuracy, and cost through structured evaluation tools.
+
+> **Tip**
+> You can run evaluations directly from the command line using the `gh models eval` command. It uses the same evaluators as the UI so you can test your `.prompt.yml` file locally or in CI.
+
+## Use cases for GitHub Models
+
+Model behavior can vary widely based on the prompt, input, or configuration. GitHub Models helps you:
+
+- Test and compare multiple LLMs across realistic use cases.
+- Optimize prompt phrasing, temperature, and other parameters.
+- Evaluate model outputs using structured, repeatable metrics.
+- Make AI development integrated into your development workflow.
+
+## Example scenario
+
+Suppose you're building a feature to summarise customer feedback submitted through support tickets. These summaries will be used for internal reports, so the output must be clear and concise.
+
+You want to:
+
+- Experiment with different models and prompt configurations.
+- Evaluate the best-performing configuration based on quality, consistency, and efficiency.
+- Save the configuration to your repository for reuse and collaboration.
+
+## Prompt testing in the Playground
+
+To get started, open the Playground and configure a model. Define a system prompt like:
+
+```text
+You are a helpful assistant that summarises support ticket responses into concise summaries.
+```
+
+Enter a sample user prompt describing an issue, then run the model to see the generated summary. Refine the prompt until the output is concise and relevant.
+
+### Using variables in prompts
+
+At the bottom of the parameters settings, click **Create prompt.yml file** to open the Prompt view. Use variables in your prompt text wrapped in double curly braces, for example:
+
+```text
+Travel or shopping assistants using {{city}}, {{intent}}, and {{budget}} to tailor recommendations.
+```
+
+The variables will become parameters in compare mode so that you can reuse the prompt with different inputs.
+
+## Adding test inputs
+
+Switch to the Comparisons view to run structured tests. Each row represents an input and expected output. Add rows with realistic support messages and their ideal summaries.
+
+## Adjusting model parameters
+
+Create additional prompt configurations to compare models or parameter sets. For example, choose **PHI-4** from the model dropdown and set parameters like `max_tokens: 128` and `temperature: 0.3` to keep responses short and deterministic.
+
+## Evaluating outputs
+
+Apply evaluators such as **similarity**, **relevance**, and **groundedness** to measure how well each output matches your expectations. You can also define a custom prompt evaluator for specialised checks. Click **Run** to generate outputs and scores.
+
+### Test case: PDF upload crash
+
+Input: *The app crashes every time I try to upload a PDF from my phone. It works on desktop but not on mobile.*
+
+Compare each model's output and evaluator scores to determine which configuration best summarises the issue.
+
+### Test case: Dark mode request
+
+Input: *Please add dark mode. It's very hard to use at night. My eyes hurt after prolonged use.*
+
+Review the outputs and evaluator scores to judge which model captures the user's intent most effectively without unnecessary commentary.
+
+## Save the configuration
+
+After completing your evaluations, choose the best-performing model and prompt configuration. Add a descriptive name to the prompt file and commit the changes. This stores the model, parameters, and dataset as a reusable configuration file in your repository.
+
+## Further reading
+
+- [Prototyping with AI Models](prototyping_with_ai_models.md)
+- [Optimizing your AI-powered app with Models](optimizing_with_models.md)
+- [GitHub Models Overview](github_models.md)

--- a/docs/github_models.md
+++ b/docs/github_models.md
@@ -1,0 +1,36 @@
+# GitHub Models Overview
+
+GitHub Models is a suite of developer tools for experimenting with and evaluating large language models. It provides prompt management, side by side comparisons and structured metrics to help teams adopt AI responsibly.
+
+## Capabilities
+
+- **Prompt development** – Work with prompts in a structured editor supporting system instructions, test inputs and variables.
+- **Model comparison** – Run identical prompts against multiple models and inspect the outputs side by side.
+- **Evaluators** – Score similarity, relevance and groundedness to track performance over time.
+- **Prompt configurations** – Save settings as `.prompt.yml` files in the repository for review and reproducibility.
+- **Production integration** – Use saved configurations through SDKs or the REST API.
+
+## Enabling GitHub Models
+
+Individuals can enable GitHub Models from the repository settings under **Models**. For organizations, an enterprise owner first enables the feature so organization owners can configure allowed models.
+
+## Prompts
+
+Each prompt configuration lives as a `.prompt.yml` file defining the model, parameters and test inputs. Manage, edit and organize these files to support experimentation or production use.
+
+## Comparisons
+
+Use the Comparisons view to evaluate multiple configurations across rows of input data. The view displays evaluator scores, making it ideal for refining prompts and avoiding regressions.
+
+## Playground
+
+The Playground lets you quickly explore models and test prompt ideas in real time. Adjust parameters and compare responses interactively during early experimentation.
+
+## Billing
+
+See [About billing for GitHub Models](https://docs.github.com) for details on pricing.
+
+## Community
+
+Join the [GitHub Models discussion](https://github.com/github/community) to share feedback and learn how others use the tooling.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,3 +5,4 @@ Welcome to the documentation for the Protocol to CRF Generator project. This too
 The full documentation set, including design specifications and requirements, is organised under the `spec` folder. See the [Documentation Table of Contents](spec/table-of-contents.md) for an overview of all available documents.
 
 You can now explore our [GitHub Models overview](github_models.md) to understand how large language models are incorporated into the project. Learn more about [prototyping with AI models](prototyping_with_ai_models.md) to experiment with different options.
+For step-by-step guidance on refining prompts, read [Optimizing your AI-powered app with Models](optimizing_with_models.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,3 +6,4 @@ The full documentation set, including design specifications and requirements, is
 
 You can now explore our [GitHub Models overview](github_models.md) to understand how large language models are incorporated into the project. Learn more about [prototyping with AI models](prototyping_with_ai_models.md) to experiment with different options.
 For step-by-step guidance on refining prompts, read [Optimizing your AI-powered app with Models](optimizing_with_models.md).
+To learn how to test and score model outputs, see [Evaluating AI models](evaluating_ai_models.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,3 +8,4 @@ You can now explore our [GitHub Models overview](github_models.md) to understand
 For step-by-step guidance on refining prompts, read [Optimizing your AI-powered app with Models](optimizing_with_models.md).
 To learn how to test and score model outputs, see [Evaluating AI models](evaluating_ai_models.md).
 For details on storing prompts, read [Storing prompts in GitHub repositories](storing_prompts.md).
+To integrate models into your workflow, see [Integrating AI models into your development workflow](integrating_ai_models.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,3 +7,4 @@ The full documentation set, including design specifications and requirements, is
 You can now explore our [GitHub Models overview](github_models.md) to understand how large language models are incorporated into the project. Learn more about [prototyping with AI models](prototyping_with_ai_models.md) to experiment with different options.
 For step-by-step guidance on refining prompts, read [Optimizing your AI-powered app with Models](optimizing_with_models.md).
 To learn how to test and score model outputs, see [Evaluating AI models](evaluating_ai_models.md).
+For details on storing prompts, read [Storing prompts in GitHub repositories](storing_prompts.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,3 +3,5 @@
 Welcome to the documentation for the Protocol to CRF Generator project. This tool converts clinical study protocols into CDISC-compliant Case Report Form artefacts.
 
 The full documentation set, including design specifications and requirements, is organised under the `spec` folder. See the [Documentation Table of Contents](spec/table-of-contents.md) for an overview of all available documents.
+
+You can now explore our [GitHub Models overview](github_models.md) to understand how large language models are incorporated into the project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,4 +4,4 @@ Welcome to the documentation for the Protocol to CRF Generator project. This too
 
 The full documentation set, including design specifications and requirements, is organised under the `spec` folder. See the [Documentation Table of Contents](spec/table-of-contents.md) for an overview of all available documents.
 
-You can now explore our [GitHub Models overview](github_models.md) to understand how large language models are incorporated into the project.
+You can now explore our [GitHub Models overview](github_models.md) to understand how large language models are incorporated into the project. Learn more about [prototyping with AI models](prototyping_with_ai_models.md) to experiment with different options.

--- a/docs/integrating_ai_models.md
+++ b/docs/integrating_ai_models.md
@@ -1,0 +1,91 @@
+# Integrating AI models into your development workflow
+
+Call AI models in the tools you use every day.
+
+## Using AI models in Copilot Chat
+
+With GitHub Models extensions, you can ask specific models for help directly in Copilot Chat.
+
+### Using the GitHub Models Copilot Extension
+
+> **Note**
+> The extension is in public preview and may change.
+
+1. Install the GitHub Models Copilot Extension.
+   - Copilot Pro users can install it personally.
+   - Copilot Business or Enterprise users need an owner to enable Copilot Extensions and install the extension for the organisation.
+2. Open any Copilot Chat implementation that supports extensions.
+3. In the chat window, type `@models YOUR-PROMPT` and send your prompt.
+   - Get model recommendations based on your criteria.
+   - Execute prompts using a specific model.
+   - List models available through GitHub Models.
+
+### Using multiple model support in Copilot Chat
+
+You can also choose a model for a conversation using multi-model Copilot Chat. See the official docs for details.
+
+## Using AI models with GitHub Actions
+
+Call models from your CI pipelines using the GitHub Actions token.
+
+### Setting permissions
+
+Enable the `models` permission in your workflow so that jobs can access the inference API.
+
+### Writing your workflow file
+
+```yaml
+name: Use GitHub Models
+
+on:
+  workflow_dispatch:
+
+permissions:
+  models: read
+
+jobs:
+  call-model:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call AI model
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl "https://models.github.ai/inference/chat/completions" \
+             -H "Content-Type: application/json" \
+             -H "Authorization: Bearer $GITHUB_TOKEN" \
+             -d '{
+              "messages": [
+                  {
+                     "role": "user",
+                     "content": "Explain the concept of recursion."
+                  }
+               ],
+               "model": "openai/gpt-4o"
+            }'
+```
+
+## Using AI models from the command line
+
+> **Note**
+> The GitHub Models CLI extension is in public preview and may change.
+
+Install the extension and prompt models from your terminal.
+
+### Prerequisites
+
+Install [GitHub CLI](https://github.com/cli/cli) and authenticate with `gh auth login`.
+
+### Installing the extension
+
+```shell
+gh extension install https://github.com/github/gh-models
+```
+
+### Using the extension
+
+- Run `gh models` to list commands.
+- Start a chat: `gh models run` and select a model.
+- Ask a single question: `gh models run MODEL "QUESTION"`.
+- Pipe command output as context: `cat README.md | gh models run openai/gpt-4.1 "summarise this text"`.
+

--- a/docs/optimizing_with_models.md
+++ b/docs/optimizing_with_models.md
@@ -1,0 +1,53 @@
+# Optimizing your AI-powered app with Models
+
+Learn how to test models and refine prompts using GitHub Models to build a better AI-powered application.
+
+## Testing a prompt
+
+The Comparisons view lets you tweak model parameters and prompts to observe how models respond.
+
+1. **Create a sample repository** named `models-playground` and open the **Models** tab.
+1. **Create a new prompt** from the *Prompts* section and choose a model.
+1. **Write a system prompt** that instructs the model how to behave. For example:
+
+```text
+You are an expert at using the Git version control system. I will ask questions looking for guidance on the best way to perform tasks using Git, and you will give clear, step-by-step answers that explain each step you are recommending.
+```
+
+1. **Write a user prompt** with an input placeholder:
+
+```text
+I want to learn how to use Git from the command line.
+```
+
+1. **Enter sample input** using the `{{input}}` variable, e.g. `When should I use rebase or merge?`.
+1. **Run the sample prompt** with the *Play* button and experiment with changes.
+
+## Testing different models against a prompt
+
+Use the **Comparisons** view to duplicate your prompt and select different models. Add rows of input such as:
+
+- `How do I modify the most recent commit message in my current branch?`
+- `How do I move a specific commit from one branch to a different branch?`
+- `How do I find the author of a specific commit in a repository's history?`
+
+Run the prompts to compare latency and token usage across models.
+
+## Testing prompt variations with a specific model
+
+If you have chosen a model, vary the user prompt to see how wording affects the output. Examples:
+
+- `I want to learn how to use Git from the command line, but explain it to me like I am five years old.`
+- `I want to learn how to use Git from the command line. Give me instructions in the form of a haiku.`
+
+Run the prompts again and compare the responses.
+
+## Evaluating model output
+
+Track token usage and latency to manage cost and performance. Use **Evaluators** such as *String check* to verify that outputs contain required strings. For example, add an evaluator named "Amend check" with value `git commit --amend` and run the prompts to see which responses pass.
+
+## Next steps
+
+Store your chosen prompt configuration as a `.prompt.yml` file in the repository to enable version control and collaboration.
+
+Join the [GitHub Models discussion](https://github.com/github/community/discussions/55083) to learn how others are using Models.

--- a/docs/prototyping_with_ai_models.md
+++ b/docs/prototyping_with_ai_models.md
@@ -1,0 +1,53 @@
+# Prototyping with AI Models
+
+Find and experiment with AI models for free using GitHub Models.
+
+## Finding AI models
+
+1. Go to <https://github.com/marketplace/models>.
+2. Click **Model: Select a Model** at the top left of the page and choose a model.
+3. Alternatively, choose **View all models** from the dropdown, select a model in Marketplace, then click **Playground**.
+
+The model opens in the playground with details in the sidebar.
+
+## Experimenting in the playground
+
+The playground lets you adjust parameters and submit prompts to see model responses. It supports side‑by‑side comparison and is rate limited during the public preview.
+
+Use the **Parameters** tab to modify inference settings and switch to the **Code** tab to view example code.
+
+## Comparing models
+
+Click **Compare** to open a second chat window and evaluate two models at once. Any parameters you set apply to both models.
+
+## Evaluating AI models
+
+Use the Comparisons view to run evaluators such as similarity, relevance and groundedness across prompt configurations. You can also define custom evaluators. See [Evaluating outputs](https://docs.github.com).
+
+## Experimenting using the API
+
+Free API usage lets you call models from your own code. Open the **Code** tab in the playground to see example requests and SDK options. Authenticate with a personal access token that has `models:read` permission.
+
+## Saving and sharing experiments
+
+Create presets to save parameters and optional chat history. Load, edit, share or delete presets from the **Preset** dropdown.
+
+## Using the prompt editor
+
+The prompt editor provides a dedicated single-turn view for refining prompts. Access it from the **Prompt editor** button in the playground.
+
+## Experimenting in Visual Studio Code
+
+Install the pre-release **AI Toolkit** extension. Authorise it with GitHub, then open the Model Catalog under **My models**. Choose **Try in playground** for remote models or **Download** to run locally.
+
+## Going to production
+
+Free usage has request and token limits. When ready for production, opt in to paid usage or bring your own API keys.
+
+## Rate limits
+
+Limits depend on model type and Copilot plan. Requests per minute, tokens per request and concurrent requests vary. See [Azure AI Foundry Models quotas and limits](https://learn.microsoft.com) for production tiers.
+
+## Leaving feedback
+
+Join the [GitHub Models discussion](https://github.com/github/community/discussions/55083) to share feedback and learn how others are using Models.

--- a/docs/spec/1_Vision & Scope/1_Project Charter + Vision Statement/project_charter.md
+++ b/docs/spec/1_Vision & Scope/1_Project Charter + Vision Statement/project_charter.md
@@ -21,6 +21,7 @@ The **Protocol to CRF Generator** will let a single developer instantly conv
 * Command‑line interface and REST micro‑service
 * GitHub Actions CI with schema validation & unit tests
 * MIT‑licensed codebase and docs
+* Prompt iteration and model evaluation using **GitHub Models**
 
 ### Out‑of‑Scope
 

--- a/docs/storing_prompts.md
+++ b/docs/storing_prompts.md
@@ -1,0 +1,52 @@
+# Storing prompts in GitHub repositories
+
+Store prompts directly in your GitHub repositories to leverage automated text summarisation and other AI-driven features.
+
+## Benefits
+
+- Easy integration with GitHub's suite of AI development tools.
+- Simple and scalable for a range of use cases.
+- Uses a widely supported format compatible with existing tooling.
+
+## Supported file format
+
+Prompts are stored as YAML files anywhere in the repository using the `.prompt.yml` or `.prompt.yaml` extension.
+
+Example:
+
+```yaml
+name: Text Summarizer
+description: Summarises input text concisely
+model: gpt-4o-mini
+modelParameters:
+  temperature: 0.5
+messages:
+  - role: system
+    content: You are a text summariser. Your only job is to summarise text given to you.
+  - role: user
+    content: |
+      Summarise the given text, beginning with "Summary -":
+      <text>
+      {{input}}
+      </text>
+testData:
+  - input: |
+      The quick brown fox jumped over the lazy dog.
+      The dog was too tired to react.
+    expected: Summary - A fox jumped over a lazy, unresponsive dog.
+evaluators:
+  - name: Output should start with 'Summary -'
+    string:
+      startsWith: 'Summary -'
+```
+
+## Prompt structure
+
+Prompts include:
+
+- **Runtime information** such as system and user templates with `{{variable}}` placeholders.
+- **Development information** like a human-readable name, description, model settings, sample data and evaluator details.
+
+## Limitations
+
+Prompts cannot be stored in proprietary or complex formats and do not support advanced templating languages.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,3 +23,4 @@ nav:
   - Prototyping with AI Models: prototyping_with_ai_models.md
   - Optimizing with Models: optimizing_with_models.md
   - Evaluating AI Models: evaluating_ai_models.md
+  - Storing Prompts: storing_prompts.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,3 +20,4 @@ nav:
   - Design: spec/design.md
   - Requirements: spec/requirements.md
   - GitHub Models: github_models.md
+  - Prototyping with AI Models: prototyping_with_ai_models.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,3 +21,4 @@ nav:
   - Requirements: spec/requirements.md
   - GitHub Models: github_models.md
   - Prototyping with AI Models: prototyping_with_ai_models.md
+  - Optimizing with Models: optimizing_with_models.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,3 +19,4 @@ nav:
   - Technical Plan: spec/technical-plan.md
   - Design: spec/design.md
   - Requirements: spec/requirements.md
+  - GitHub Models: github_models.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,3 +24,4 @@ nav:
   - Optimizing with Models: optimizing_with_models.md
   - Evaluating AI Models: evaluating_ai_models.md
   - Storing Prompts: storing_prompts.md
+  - Integrating AI Models: integrating_ai_models.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,3 +22,4 @@ nav:
   - GitHub Models: github_models.md
   - Prototyping with AI Models: prototyping_with_ai_models.md
   - Optimizing with Models: optimizing_with_models.md
+  - Evaluating AI Models: evaluating_ai_models.md


### PR DESCRIPTION
## Summary
- create GitHub Models overview page
- link GitHub Models in index and nav
- adjust project charter scope
- add task for documenting GitHub Models

## Testing
- `pre-commit run --all-files`
- `pytest -n auto --cov --cov-fail-under=90` *(fails: ModuleNotFoundError, coverage 0%)*

------
https://chatgpt.com/codex/tasks/task_e_688101d58588832c8b1ae3f7dcb4230a